### PR TITLE
Expose Google Home, Home Mini, Nest Hub, and Cast Groups

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ function ControlChromecastPlatform(log, config, api) {
 ControlChromecastPlatform.prototype.scanAccesories = function () {
 
   let addChromecast = function(device){
-    if(device && device.txtRecord && ['Chromecast', 'Chromecast Audio'].indexOf(device.txtRecord.md) !== -1){
+    if(device && device.txtRecord && ['Chromecast', 'Chromecast Audio', 'Google Cast Group', 'Google Nest Hub', 'Google Home', 'Google Home Mini'].indexOf(device.txtRecord.md) !== -1){
       let uuid = UUIDGen.generate(device.txtRecord.id);
       let accessory = this.accessories[uuid];
 


### PR DESCRIPTION
I was trying the plugin and it only showed the Chromecast connected to my TV.

I realised it was because you were filtering out my other devices (Home, Home Mini, Nest Hub) and the Cast Groups that allow playing in multiple devices at the same time.

This simple change enables those devices.